### PR TITLE
Improving BeeUpgradeModule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ mainClassName = "br.com.bluesoft.bee.Bee"
 
 group = 'br.com.bluesoft.bee'
 def artifact = 'bee'
-version = '1.54'
+version = '1.55'
 
 def startScriptsDir = new File("$buildDir/scripts")
 

--- a/src/main/groovy/br/com/bluesoft/bee/BeeFileUtils.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/BeeFileUtils.groovy
@@ -78,6 +78,22 @@ public class BeeFileUtils {
 		dir.delete()
 	}
 	
+	def static removeOldBees(File dir) {
+		def libfolder =  new File(dir.getPath(), "/lib")
+
+		if(libfolder.isDirectory()) {
+			String[] files = libfolder.list()
+
+			for(String file: files) {
+				File f  = new File(libfolder, file)
+
+				if (f.getName().matches("bee-[0-9]+\\.[0-9]+\\.jar")) {
+					if (f.getName() != "bee-" + BeeVersionModule.getLatestVersion() + ".jar") f.delete()
+				}
+			}
+		}
+	}
+
 	def static copyFolder(File source, File destination) {
 		InputStream  is
 		OutputStream out
@@ -92,6 +108,8 @@ public class BeeFileUtils {
 				copyFolder(src_file, dest_file)
 			}
 		} else {
+			if (destination.exists()) destination.delete()
+
 			try {
 				destination.getParentFile().mkdirs()
 

--- a/src/main/groovy/br/com/bluesoft/bee/BeeUpgradeModule.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/BeeUpgradeModule.groovy
@@ -149,12 +149,10 @@ public class BeeUpgradeModule implements BeeWriter {
 		def source = TMPDIR + '/bee-' + version
 
 		File dest = new File(inst_dir)
-
-		BeeFileUtils.removeDir(dest)
-		BeeFileUtils.createDir(dest)
-
 		File src = new File(source)
+
 		BeeFileUtils.copyFolder(src, dest)
+		BeeFileUtils.removeOldBees(dest)
 	}
 	
 	def static getAppPath() {


### PR DESCRIPTION
Bee will now only delete the destination files that it has in its
source.

Without this change, Bee could delete the basefolder where it was
located which could lead to some problems depending on where it was
installed.

Also there's a piece of code that deletes old jar files of Bee.