### PR TITLE
Exits if the latest release name is not following the pattern we are already using

### DIFF
--- a/src/main/groovy/br/com/bluesoft/bee/BeeUpgradeModule.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/BeeUpgradeModule.groovy
@@ -36,6 +36,8 @@ import java.io.File;
 import br.com.bluesoft.bee.service.*
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 
 public class BeeUpgradeModule implements BeeWriter {
 	static private String TMPDIR  = System.getProperty("java.io.tmpdir") + "/bee-upgrade"
@@ -114,7 +116,20 @@ public class BeeUpgradeModule implements BeeWriter {
 	}
 
 	def static getLatestVersion() {
-		return BeeVersionModule.getLatestVersion()
+		def version_latest = BeeVersionModule.getLatestVersion()
+
+		def m = version_latest ==~ /^([0-9]+)\.([0-9]+)$/
+		assert m instanceof Boolean
+
+		if (!m) {
+			def msg = "Fatal error: latest release name does not match the name pattern: N.N, e.g. 15.12.\n"
+			msg += "Please open an issue with this output: https://github.com/bluesoft/bee/issues\n"
+			msg += "Exiting.\n"
+
+			die(msg)
+		}
+
+		return version_latest
 	}
 
 	def static isLatestVersion() {
@@ -132,7 +147,6 @@ public class BeeUpgradeModule implements BeeWriter {
 
 		BeeFileUtils.downloadFile(url_download, local_file)
 	}
-
 
 	def static applyChanges() {
 		String app_path = getAppPath()
@@ -160,6 +174,11 @@ public class BeeUpgradeModule implements BeeWriter {
 		String inst_dir = app_path.replaceAll("lib/bee-[0-9]+\\.[0-9]+\\.jar", "")
 
 		return inst_dir
+	}
+
+	def static die(String msg) {
+		println msg
+		System.exit 1
 	}
 
 	void log(String msg) {

--- a/src/test/groovy/br/com/bluesoft/bee/BeeUpgradeModuleTest.groovy
+++ b/src/test/groovy/br/com/bluesoft/bee/BeeUpgradeModuleTest.groovy
@@ -37,11 +37,10 @@ public class BeeUpgradeModuleTest extends Specification {
 		then:""
 		isLatest == false
 	}
-	
+
 	@Test
 	def "deve pegar a última versão e ela deve ser igual à versão retornada no módulo BeeVersionModule"() {
 		given:""
-		GroovyMock(BeeVersionModule, global: true)
 		def beeVersionLatest = BeeVersionModule.getLatestVersion()
 
 		when:""
@@ -49,6 +48,23 @@ public class BeeUpgradeModuleTest extends Specification {
 		def beeUpgradeLatest = upgrade.getLatestVersion()
 
 		then:""
-		 beeUpgradeLatest == beeVersionLatest
+		beeUpgradeLatest == beeVersionLatest
+	}
+
+	@Test
+	def "deve abortar a execução porque o nome do release está fora do padrão"() {
+		given:""
+		GroovyMock(BeeVersionModule, global: true)
+		BeeVersionModule.getLatestVersion() >> "v1.1"
+
+		GroovyMock(System, global: true)
+		System.exit() >> 1
+
+		when:""
+		BeeUpgradeModule upgrade = new BeeUpgradeModule()
+		def version = upgrade.getLatestVersion()
+
+		then:""
+		assert 1
 	}
 }


### PR DESCRIPTION
Bee release names must have a pattern for the upgrade module to work correctly. I thought it would be good to guarantee that the release names are correct, so I'm sending this patch that makes Bee exit when the release name does not have the pattern we desire.

Do you think we need to guarantee that in the code or we just can pay attention when we create the release names?
