### PR TITLE
Multi-database support

### DIFF
--- a/src/main/groovy/br/com/bluesoft/bee/database/reader/DatabaseReader.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/database/reader/DatabaseReader.groovy
@@ -37,4 +37,5 @@ import br.com.bluesoft.bee.model.Schema
 interface DatabaseReader {
 
     def Schema getSchema(objectName)
+    def cleanupSchema(Schema schema)
 }

--- a/src/main/groovy/br/com/bluesoft/bee/database/reader/MySqlDatabaseReader.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/database/reader/MySqlDatabaseReader.groovy
@@ -338,7 +338,7 @@ class MySqlDatabaseReader implements DatabaseReader {
         rows.each({
             def view = new View()
             view.name = it.view_name
-            view.text = it.text
+            view.text_mysql = it.text
             views[view.name] = view
         })
         return views
@@ -399,7 +399,7 @@ class MySqlDatabaseReader implements DatabaseReader {
                 if (name) {
                     def procedure = procedures[name]
 					if (procedure) {
-						procedure.text = body
+						procedure.text_mysql = body
 					}
                 }
                 name = it.name
@@ -409,7 +409,7 @@ class MySqlDatabaseReader implements DatabaseReader {
         })
         def procedure = procedures[name]
 		if (procedure) {
-			procedure.text = body
+			procedure.text_mysql = body
 		}
     }
 
@@ -440,12 +440,17 @@ class MySqlDatabaseReader implements DatabaseReader {
 
         rows.each({
             def triggerName = it.name
-            def trigger = triggers[triggerName] ?: new Trigger()
-            trigger.name = triggerName
-            trigger.text += it.text
+            def trigger = triggers[triggerName] ?: new Trigger(name: triggerName, text_mysql: '')
+            trigger.text_mysql += it.text
             triggers[triggerName] = trigger
         })
 
         return triggers
     }
+
+    def cleanupSchema(Schema schema) {
+        schema.userTypes.clear()
+        schema.packages.clear()
+    }
+
 }

--- a/src/main/groovy/br/com/bluesoft/bee/database/reader/OracleDatabaseReader.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/database/reader/OracleDatabaseReader.groovy
@@ -12,6 +12,7 @@ import br.com.bluesoft.bee.model.TableColumn
 import br.com.bluesoft.bee.model.Trigger
 import br.com.bluesoft.bee.model.UserType
 import br.com.bluesoft.bee.model.View
+import br.com.bluesoft.bee.util.RDBMS
 
 class OracleDatabaseReader implements DatabaseReader {
 
@@ -374,7 +375,7 @@ class OracleDatabaseReader implements DatabaseReader {
         rows.each({
             def view = new View()
             view.name = it.view_name.toLowerCase()
-            view.text = it.text
+            view.text_oracle = it.text
             views[view.name] = view
         })
         return views
@@ -441,7 +442,7 @@ class OracleDatabaseReader implements DatabaseReader {
                 if (name) {
                     def procedure = procedures[name]
 					if (procedure) {
-						procedure.text = body
+						procedure.text_oracle = body
 					}
                 }
                 name = it.name.toLowerCase()
@@ -451,7 +452,7 @@ class OracleDatabaseReader implements DatabaseReader {
         })
         def procedure = procedures[name]
 		if (procedure) {
-			procedure.text = body
+			procedure.text_oracle = body
 		}
     }
 
@@ -520,9 +521,8 @@ class OracleDatabaseReader implements DatabaseReader {
 
         rows.each({
             def triggerName = it.name.toLowerCase()
-            def trigger = triggers[triggerName] ?: new Trigger()
-            trigger.name = triggerName
-            trigger.text += it.text
+            def trigger = triggers[triggerName] ?: new Trigger(name: triggerName, text_oracle: '')
+            trigger.text_oracle += it.text
             triggers[triggerName] = trigger
         })
 
@@ -552,5 +552,9 @@ class OracleDatabaseReader implements DatabaseReader {
         })
 
         return userTypes
+    }
+
+    def cleanupSchema(Schema schema) {
+
     }
 }

--- a/src/main/groovy/br/com/bluesoft/bee/model/Constraint.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/model/Constraint.groovy
@@ -35,7 +35,9 @@ package br.com.bluesoft.bee.model
 import br.com.bluesoft.bee.model.message.Message
 import br.com.bluesoft.bee.model.message.MessageLevel
 import br.com.bluesoft.bee.model.message.MessageType
+import groovy.transform.AutoClone
 
+@AutoClone
 class Constraint {
 
     String name

--- a/src/main/groovy/br/com/bluesoft/bee/model/Index.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/model/Index.groovy
@@ -35,7 +35,9 @@ package br.com.bluesoft.bee.model
 import br.com.bluesoft.bee.model.message.Message
 import br.com.bluesoft.bee.model.message.MessageLevel
 import br.com.bluesoft.bee.model.message.MessageType
+import org.codehaus.jackson.annotate.JsonAutoDetect
 
+@JsonAutoDetect(isGetterVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.ANY)
 class Index {
 
     String name
@@ -63,4 +65,5 @@ class Index {
 
         return messages
     }
+
 }

--- a/src/main/groovy/br/com/bluesoft/bee/model/IndexColumn.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/model/IndexColumn.groovy
@@ -32,6 +32,9 @@
  */
 package br.com.bluesoft.bee.model
 
+import org.codehaus.jackson.annotate.JsonAutoDetect
+
+@JsonAutoDetect(isGetterVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.ANY)
 class IndexColumn {
 
     String name
@@ -53,4 +56,5 @@ class IndexColumn {
     boolean equals(other) {
         this.name == other.name && this.descend == other.descend
     }
+
 }

--- a/src/main/groovy/br/com/bluesoft/bee/model/Procedure.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/model/Procedure.groovy
@@ -35,12 +35,16 @@ package br.com.bluesoft.bee.model
 import br.com.bluesoft.bee.model.message.Message
 import br.com.bluesoft.bee.model.message.MessageLevel
 import br.com.bluesoft.bee.model.message.MessageType
+import br.com.bluesoft.bee.util.RDBMS
 import br.com.bluesoft.bee.util.StringUtil
 
 class Procedure implements Validator {
 
     def name
     def text
+    def text_oracle
+    def text_postgres
+    def text_mysql
     def schema
 
     List validateWithMetadata(metadataProcedure) {
@@ -57,4 +61,25 @@ class Procedure implements Validator {
 
         return messages
     }
-}
+
+    Procedure getCanonical(RDBMS rdbms) {
+        if(rdbms == null) {
+            return this
+        }
+
+        String text
+        switch(rdbms) {
+            case RDBMS.ORACLE:
+                text = text_oracle ?: this.text
+                break
+            case RDBMS.POSTGRES:
+                text = text_postgres ?: this.text
+                break
+            case RDBMS.MYSQL:
+                text = text_mysql ?: this.text
+                break
+        }
+
+        new Procedure(name: name, text: text)
+    }}
+

--- a/src/main/groovy/br/com/bluesoft/bee/model/Table.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/model/Table.groovy
@@ -35,7 +35,11 @@ package br.com.bluesoft.bee.model
 import br.com.bluesoft.bee.model.message.Message
 import br.com.bluesoft.bee.model.message.MessageLevel
 import br.com.bluesoft.bee.model.message.MessageType
+import groovy.transform.AutoClone
+import org.codehaus.jackson.annotate.JsonAutoDetect
 
+@AutoClone
+@JsonAutoDetect(isGetterVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.ANY)
 class Table implements Validator {
 
     String name
@@ -157,4 +161,5 @@ class Table implements Validator {
         }
         return messages
     }
+
 }

--- a/src/main/groovy/br/com/bluesoft/bee/model/TableColumn.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/model/TableColumn.groovy
@@ -35,9 +35,14 @@ package br.com.bluesoft.bee.model
 import br.com.bluesoft.bee.model.message.Message
 import br.com.bluesoft.bee.model.message.MessageLevel
 import br.com.bluesoft.bee.model.message.MessageType
+import groovy.transform.AutoClone
+import org.codehaus.jackson.annotate.JsonAutoDetect
+import org.codehaus.jackson.annotate.JsonIgnore
 
 import java.text.MessageFormat
 
+@AutoClone
+@JsonAutoDetect(isGetterVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.ANY)
 class TableColumn {
 
     String name

--- a/src/main/groovy/br/com/bluesoft/bee/model/Trigger.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/model/Trigger.groovy
@@ -35,12 +35,16 @@ package br.com.bluesoft.bee.model
 import br.com.bluesoft.bee.model.message.Message
 import br.com.bluesoft.bee.model.message.MessageLevel
 import br.com.bluesoft.bee.model.message.MessageType
+import br.com.bluesoft.bee.util.RDBMS
 import br.com.bluesoft.bee.util.StringUtil
 
 class Trigger implements Validator {
 
     def name
-    def text = ''
+    def text
+    def text_oracle
+    def text_postgres
+    def text_mysql
 
     List validateWithMetadata(metadataPackage) {
 		if (!metadataPackage instanceof Package) {
@@ -56,4 +60,26 @@ class Trigger implements Validator {
 
         return messages
     }
+
+    Trigger getCanonical(RDBMS rdbms) {
+        if(rdbms == null) {
+            return this
+        }
+
+        String text
+        switch(rdbms) {
+            case RDBMS.ORACLE:
+                text = text_oracle ?: this.text
+                break
+            case RDBMS.POSTGRES:
+                text = text_postgres ?: this.text
+                break
+            case RDBMS.MYSQL:
+                text = text_mysql ?: this.text
+                break
+        }
+
+        new Trigger(name: name, text: text)
+    }
 }
+

--- a/src/main/groovy/br/com/bluesoft/bee/model/View.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/model/View.groovy
@@ -35,12 +35,16 @@ package br.com.bluesoft.bee.model
 import br.com.bluesoft.bee.model.message.Message
 import br.com.bluesoft.bee.model.message.MessageLevel
 import br.com.bluesoft.bee.model.message.MessageType
+import br.com.bluesoft.bee.util.RDBMS
 import br.com.bluesoft.bee.util.StringUtil
 
 class View implements Validator {
 
     def name
     def text
+    def text_oracle
+    def text_postgres
+    def text_mysql
 
     List validateWithMetadata(metadataView) {
         if (!(metadataView instanceof View)) {
@@ -54,5 +58,26 @@ class View implements Validator {
         }
 
         return messages
+    }
+
+    View getCanonical(RDBMS rdbms) {
+        if(rdbms == null) {
+            return this
+        }
+
+        String text
+        switch(rdbms) {
+            case RDBMS.ORACLE:
+                text = text_oracle ?: this.text
+                break
+            case RDBMS.POSTGRES:
+                text = text_postgres ?: this.text
+                break
+            case RDBMS.MYSQL:
+                text = text_mysql ?: this.text
+                break
+        }
+
+        new View(name: name, text: text)
     }
 }

--- a/src/main/groovy/br/com/bluesoft/bee/model/rule/DataType.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/model/rule/DataType.groovy
@@ -1,0 +1,12 @@
+package br.com.bluesoft.bee.model.rule
+
+import org.codehaus.groovy.util.HashCodeHelper
+
+class DataType {
+    String fromType
+    Integer fromSize
+    Integer fromScale
+    String toType
+    Integer toSize
+    Integer toScale
+}

--- a/src/main/groovy/br/com/bluesoft/bee/model/rule/Rule.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/model/rule/Rule.groovy
@@ -1,0 +1,11 @@
+package br.com.bluesoft.bee.model.rule
+
+class Rule {
+    List<DataType> dataTypeOut = []
+    Map<String, Map<String, String>> columnDefaultOut = [:]
+    Map<String, String> checkConditionIn = [:]
+
+    List<DataType> dataTypeIn = []
+    Map<String, Map<String, String>> columnDefaultIn = [:]
+    Map<String, String> checkConditionOut = [:]
+}

--- a/src/main/groovy/br/com/bluesoft/bee/schema/BeeMySqlSchemaCreatorAction.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/schema/BeeMySqlSchemaCreatorAction.groovy
@@ -4,6 +4,8 @@ import br.com.bluesoft.bee.importer.JsonImporter
 import br.com.bluesoft.bee.model.Options
 import br.com.bluesoft.bee.runner.ActionRunner
 import br.com.bluesoft.bee.service.BeeWriter
+import br.com.bluesoft.bee.service.RulesConverter
+import br.com.bluesoft.bee.util.RDBMS
 
 class BeeMySqlSchemaCreatorAction implements ActionRunner {
 
@@ -25,6 +27,8 @@ class BeeMySqlSchemaCreatorAction implements ActionRunner {
 
         out.log('importing schema metadata from the reference files')
         def schema = getImporter().importMetaData()
+        schema.rdbms = RDBMS.MYSQL
+        schema = new RulesConverter().toSchema(schema)
 
 		if (objectName) {
 			schema = schema.filter(objectName)

--- a/src/main/groovy/br/com/bluesoft/bee/schema/BeeOracleSchemaCreator.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/schema/BeeOracleSchemaCreator.groovy
@@ -76,4 +76,5 @@ class BeeOracleSchemaCreator extends BeeSchemaCreator {
         result += "\n/\n"
         return result
     }
+
 }

--- a/src/main/groovy/br/com/bluesoft/bee/schema/BeeOracleSchemaCreatorAction.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/schema/BeeOracleSchemaCreatorAction.groovy
@@ -4,6 +4,8 @@ import br.com.bluesoft.bee.importer.JsonImporter
 import br.com.bluesoft.bee.model.Options
 import br.com.bluesoft.bee.runner.ActionRunner
 import br.com.bluesoft.bee.service.BeeWriter
+import br.com.bluesoft.bee.service.RulesConverter
+import br.com.bluesoft.bee.util.RDBMS
 
 public class BeeOracleSchemaCreatorAction implements ActionRunner {
 
@@ -26,6 +28,8 @@ public class BeeOracleSchemaCreatorAction implements ActionRunner {
 
         out.log('importing schema metadata from the reference files')
         def schema = getImporter().importMetaData()
+        schema.rdbms = RDBMS.ORACLE
+        schema = new RulesConverter().toSchema(schema)
 
         if (objectName) {
             schema = schema.filter(objectName)

--- a/src/main/groovy/br/com/bluesoft/bee/schema/BeePostgresSchemaCreator.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/schema/BeePostgresSchemaCreator.groovy
@@ -56,6 +56,12 @@ class BeePostgresSchemaCreator extends BeeSchemaCreator {
         }
     }
 
+    void createCoreData(def file, def schema, def dataFolderPath) {
+        if (!schema.filtered) {
+            super.createCoreData(file, schema, dataFolderPath)
+        }
+    }
+
     void createIndexes(def file, def schema) {
         def tables = schema.tables.sort()
         tables.each {
@@ -79,16 +85,21 @@ class BeePostgresSchemaCreator extends BeeSchemaCreator {
 
     void createProcedures(def file, def schema) {
         schema.procedures*.value.sort().each {
-            def procedure = "${it.text};\n\n"
+            def procedure = "${it.getCanonical(schema.rdbms).text};\n\n"
             file.append(procedure.toString(), 'utf-8')
         }
     }
 
     void createTriggers(def file, def schema) {
         schema.triggers*.value.sort().each {
-            def trigger = "${it.text};\n\n"
+            def trigger = "${it.getCanonical(schema.rdbms).text};\n\n"
             file.append(trigger.toString(), 'utf-8')
         }
     }
 
+    String toBoolean(String fieldValue) {
+        if(fieldValue == '0') return 'false'
+        if(fieldValue == '1') return 'true'
+        fieldValue
+    }
 }

--- a/src/main/groovy/br/com/bluesoft/bee/schema/BeePostgresSchemaCreatorAction.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/schema/BeePostgresSchemaCreatorAction.groovy
@@ -4,6 +4,8 @@ import br.com.bluesoft.bee.importer.JsonImporter
 import br.com.bluesoft.bee.model.Options
 import br.com.bluesoft.bee.runner.ActionRunner
 import br.com.bluesoft.bee.service.BeeWriter
+import br.com.bluesoft.bee.service.RulesConverter
+import br.com.bluesoft.bee.util.RDBMS
 
 public class BeePostgresSchemaCreatorAction implements ActionRunner {
 
@@ -25,6 +27,8 @@ public class BeePostgresSchemaCreatorAction implements ActionRunner {
 
         out.log('importing schema metadata from the reference files')
         def schema = getImporter().importMetaData()
+        schema.rdbms = RDBMS.POSTGRES
+        schema = new RulesConverter().toSchema(schema)
 
         if (objectName) {
             schema = schema.filter(objectName)

--- a/src/main/groovy/br/com/bluesoft/bee/schema/BeeSchemaValidatorAction.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/schema/BeeSchemaValidatorAction.groovy
@@ -41,6 +41,9 @@ import br.com.bluesoft.bee.model.message.MessageLevel
 import br.com.bluesoft.bee.runner.ActionRunner
 import br.com.bluesoft.bee.service.BeeWriter
 import br.com.bluesoft.bee.service.MessagePrinter
+import br.com.bluesoft.bee.service.RulesConverter
+import br.com.bluesoft.bee.util.RDBMS
+import br.com.bluesoft.bee.util.RDBMSUtil
 
 class BeeSchemaValidatorAction implements ActionRunner {
 
@@ -67,6 +70,9 @@ class BeeSchemaValidatorAction implements ActionRunner {
 
         out.log('importing schema metadata from the reference files')
         Schema metadataSchema = importer.importMetaData()
+        databaseReader.cleanupSchema(metadataSchema)
+        metadataSchema.rdbms = RDBMSUtil.getRDBMS(options)
+        metadataSchema = new RulesConverter().toSchema(metadataSchema)
 
 		if (objectName) {
 			metadataSchema = metadataSchema.filter(objectName)
@@ -74,6 +80,7 @@ class BeeSchemaValidatorAction implements ActionRunner {
 
         out.log('importing schema metadata from the database')
         Schema databaseSchema = databaseReader.getSchema(objectName)
+        databaseSchema.rdbms = RDBMSUtil.getRDBMS(options)
 
 		if (objectName) {
 			databaseSchema = databaseSchema.filter(objectName)

--- a/src/main/groovy/br/com/bluesoft/bee/service/RulesConverter.groovy
+++ b/src/main/groovy/br/com/bluesoft/bee/service/RulesConverter.groovy
@@ -1,0 +1,80 @@
+package br.com.bluesoft.bee.service
+
+import br.com.bluesoft.bee.model.Constraint
+import br.com.bluesoft.bee.model.Schema
+import br.com.bluesoft.bee.model.Table
+import br.com.bluesoft.bee.model.TableColumn
+import br.com.bluesoft.bee.model.rule.DataType
+import br.com.bluesoft.bee.model.rule.Rule
+
+class RulesConverter {
+
+    Schema toSchema(Schema source) {
+        if(!source.rules?.containsKey(source.rdbms))
+            return source
+
+        Rule rule = source.rules[source.rdbms]
+        def schema = source.clone()
+        schema.tables = source.tables.collectEntries { k, v -> [k, convertTable(v, rule.dataTypeOut, rule.columnDefaultOut, rule.checkConditionOut)]}
+        return schema
+    }
+
+    Schema fromSchema(Schema source) {
+        if(!source.rules?.containsKey(source.rdbms))
+            return source
+
+        Rule rule = source.rules[source.rdbms]
+        def schema = source.clone()
+        schema.tables = source.tables.collectEntries { k, v -> [k, convertTable(v, rule.dataTypeIn, rule.columnDefaultIn, rule.checkConditionIn)]}
+        return schema
+    }
+
+    Table convertTable(Table source, List<DataType> dataTypes, Map<String, Map<String, String>> columnDefaults, Map<String, String> checks) {
+        def result = source.clone()
+        result.columns = source.columns.collectEntries({ k, v ->
+            def dataType = findDataType(v, dataTypes)
+            return [k, convertColumn(v, dataType, columnDefaults[v.type]?[v.defaultValue])]
+        })
+        result.constraints = source.constraints.collectEntries { [it.key, convertCheckConstraint(it.value, checks)] }
+        return result
+    }
+
+    Constraint convertCheckConstraint(Constraint source, Map<String, String> checks) {
+        if(source.type == 'C' && source.searchCondition in checks) {
+            def result = source.clone()
+            result.searchCondition = checks[source.searchCondition]
+            return result
+        }
+        return source
+    }
+
+    def convertColumn(TableColumn column, DataType dataType, String defaultValue) {
+        if(dataType == null && defaultValue == null) return column
+        TableColumn result = column.clone()
+        if(dataType != null) {
+            if(dataType.toType != null) {
+                result.type = dataType.toType
+            }
+            if(dataType.toSize >= 0) {
+                result.size = dataType.toSize
+            }
+            if(dataType.toScale >= 0) {
+                result.scale = dataType.toScale
+            }
+        }
+        if(defaultValue != null) {
+            result.defaultValue = defaultValue
+        }
+        return result
+    }
+
+    DataType findDataType(TableColumn column, List<DataType> dataType) {
+        dataType.find {
+            if (column.type != it.fromType) return false
+            if ((it.fromSize ?: 0) >= 0 && column.size != it.fromSize) return false
+            if ((it.fromScale ?: 0) >= 0 && column.scale != it.fromScale) return false
+
+            return true
+        }
+    }
+}

--- a/src/test/groovy/br/com/bluesoft/bee/database/reader/MySqlDatabaseTriggerTest.groovy
+++ b/src/test/groovy/br/com/bluesoft/bee/database/reader/MySqlDatabaseTriggerTest.groovy
@@ -1,16 +1,15 @@
 package br.com.bluesoft.bee.database.reader
 
-import org.junit.Before
-import org.junit.Test
+
+import spock.lang.Specification
 
 import static org.junit.Assert.assertEquals
 
-class MySqlDatabaseTriggerTest {
+class MySqlDatabaseTriggerTest extends Specification {
 
     def reader
 
-    @Before
-    void 'set up'() {
+    void setup() {
         def triggers = [
                 [name: 'TRIGGER1', text: 'line11\n'],
                 [name: 'TRIGGER1', text: 'line12\n'],
@@ -23,17 +22,19 @@ class MySqlDatabaseTriggerTest {
         reader = new MySqlDatabaseReader(sql, 'test')
     }
 
-    @Test
-    void 'it should fill the triggers'() {
+    def 'it should fill the triggers'() {
+        expect:
         final def triggers = reader.getTriggers()
-        assertEquals 2, triggers.size()
+        2 == triggers.size()
     }
 
-    @Test
-    void 'it should fill the package name, text and body'() {
+    def 'it should fill the package name, text and body'() {
+        given:
         final def triggers = reader.getTriggers(null)
         def trigger = triggers['TRIGGER1']
-        assertEquals('TRIGGER1', trigger.name)
-        assertEquals('line11\nline12\nline13\n', trigger.text)
+
+        expect:
+        'TRIGGER1' == trigger.name
+        'line11\nline12\nline13\n' == trigger.text_mysql
     }
 }

--- a/src/test/groovy/br/com/bluesoft/bee/database/reader/OracleDatabaseTriggerTest.groovy
+++ b/src/test/groovy/br/com/bluesoft/bee/database/reader/OracleDatabaseTriggerTest.groovy
@@ -2,15 +2,15 @@ package br.com.bluesoft.bee.database.reader
 
 import org.junit.Before
 import org.junit.Test
+import spock.lang.Specification
 
 import static org.junit.Assert.assertEquals
 
-class OracleDatabaseTriggerTest {
+class OracleDatabaseTriggerTest extends Specification {
 
     def reader
 
-    @Before
-    void 'set up'() {
+    void setup() {
         def triggers = [
                 [name: 'TRIGGER1', text: 'line11\n'],
                 [name: 'TRIGGER1', text: 'line12\n'],
@@ -23,17 +23,19 @@ class OracleDatabaseTriggerTest {
         reader = new OracleDatabaseReader(sql)
     }
 
-    @Test
-    void 'it should fill the triggers'() {
+    def 'it should fill the triggers'() {
+        expect:
         final def triggers = reader.getTriggers()
-        assertEquals 2, triggers.size()
+        triggers.size() == 2
     }
 
-    @Test
-    void 'it should fill the package name, text and body'() {
+    def 'it should fill the package name, text and body'() {
+        given:
         final def triggers = reader.getTriggers(null)
         def trigger = triggers['trigger1']
-        assertEquals('trigger1', trigger.name)
-        assertEquals('line11\nline12\nline13\n', trigger.text)
+
+        expect:
+        'trigger1' == trigger.name
+        'line11\nline12\nline13\n' == trigger.text_oracle
     }
 }

--- a/src/test/groovy/br/com/bluesoft/bee/importer/JsonImporterIntegrationTest.groovy
+++ b/src/test/groovy/br/com/bluesoft/bee/importer/JsonImporterIntegrationTest.groovy
@@ -62,6 +62,7 @@ class JsonImporterIntegrationTest {
         }
 
         new File('/tmp/bee/sequences.bee') << new File(this.getClass().getResource('/sequences.bee').getFile()).getText()
+        new File('/tmp/bee/rules.json') << new File(this.getClass().getResource('/rules.json').getFile()).getText()
         importer = new JsonImporter()
     }
 

--- a/src/test/groovy/br/com/bluesoft/bee/model/SchemaPresenceValidationTest.groovy
+++ b/src/test/groovy/br/com/bluesoft/bee/model/SchemaPresenceValidationTest.groovy
@@ -65,11 +65,11 @@ class SchemaPresenceValidationTest extends spock.lang.Specification {
 
         given: "a database schema with two views"
         Schema databaseSchema = new Schema()
-        databaseSchema.views = [view_menu: new View(name: 'view_menu', text: ""), view_carneiro: new View(name: 'view_carneiro', text: "")]
+        databaseSchema.views = [view_menu: new View(name: 'view_menu', text: "x"), view_carneiro: new View(name: 'view_carneiro', text: "x")]
 
         and: "a metadata schema with two views"
         Schema metadataSchema = new Schema()
-        metadataSchema.views = [view_menu: new View(name: 'view_menu', text: ""), view_cavalo: new View(name: 'view_cavalo')]
+        metadataSchema.views = [view_menu: new View(name: 'view_menu', text: "x"), view_cavalo: new View(name: 'view_cavalo', text: "x")]
 
         when: "the schema is validated"
         def messages = databaseSchema.validateWithMetadata(metadataSchema)
@@ -105,7 +105,7 @@ class SchemaPresenceValidationTest extends spock.lang.Specification {
 
         given: "a database schema with one view called saldo_contabil_atual"
         Schema databaseSchema = new Schema()
-        databaseSchema.views = [saldo_contabil_atual: new View(name: 'saldo_contabil_atual', text: "")]
+        databaseSchema.views = [saldo_contabil_atual: new View(name: 'saldo_contabil_atual', text: "x")]
 
         and: "a metadata schema with one table also called saldo_contabil_atual"
         Schema metadataSchema = new Schema()
@@ -172,11 +172,11 @@ class SchemaPresenceValidationTest extends spock.lang.Specification {
 
         given: "a database schema with two procedures"
         Schema databaseSchema = new Schema()
-        databaseSchema.views = [proc1: new Procedure(name: 'proc1', text: ""), proc2: new Procedure(name: 'proc2', text: "")]
+        databaseSchema.views = [proc1: new Procedure(name: 'proc1', text: "x"), proc2: new Procedure(name: 'proc2', text: "x")]
 
         and: "a metadata schema with two procedures"
         Schema metadataSchema = new Schema()
-        metadataSchema.procedures = [proc1: new Procedure(name: 'proc1', text: ""), proc3: new Procedure(name: 'proc3')]
+        metadataSchema.procedures = [proc1: new Procedure(name: 'proc1', text: "x"), proc3: new Procedure(name: 'proc3', text: "x")]
 
         when: "the schema is validated"
         def messages = databaseSchema.validateWithMetadata(metadataSchema)

--- a/src/test/groovy/br/com/bluesoft/bee/model/SchemaTest.groovy
+++ b/src/test/groovy/br/com/bluesoft/bee/model/SchemaTest.groovy
@@ -10,7 +10,7 @@ class SchemaTest extends Specification {
         given:
         Schema schema = new Schema()
         schema.tables = [horses: new Table(name: 'horses')]
-        schema.views = [sheeps: new View(name: 'sheeps')]
+        schema.views = [sheeps: new View(name: 'sheeps', text: 'x')]
         schema.sequences = [bee: new Sequence(name: 'bee')]
 
         when:

--- a/src/test/groovy/br/com/bluesoft/bee/model/ViewTest.groovy
+++ b/src/test/groovy/br/com/bluesoft/bee/model/ViewTest.groovy
@@ -3,8 +3,9 @@ package br.com.bluesoft.bee.model
 import br.com.bluesoft.bee.model.message.Message
 import br.com.bluesoft.bee.model.message.MessageLevel
 import br.com.bluesoft.bee.model.message.MessageType
+import br.com.bluesoft.bee.util.RDBMS
 
-public class ViewStructrueValidationTest extends spock.lang.Specification {
+public class ViewTest extends spock.lang.Specification {
 
     def "it should return an error for each difference between the database and the reference metadata"() {
         given:
@@ -20,5 +21,20 @@ public class ViewStructrueValidationTest extends spock.lang.Specification {
         where:
         databaseView                        | messageType           | messageText
         new View(name: 'vw1', text: 'xyzw') | MessageType.VIEW_BODY | "The body of the view vw1 differs from metadata."
+    }
+
+    def getCanonicalTest() {
+        given:
+        def view_default = new View(name: "test", text: "default", text_oracle: "oracle", text_postgres: "postgres")
+        def view_nondefault = new View(name: "test", text_oracle: "oracle", text_postgres: "postgres")
+
+        expect:
+        view_default.getCanonical(RDBMS.ORACLE).text == "oracle"
+        view_default.getCanonical(RDBMS.POSTGRES).text == "postgres"
+        view_default.getCanonical(RDBMS.MYSQL).text == "default"
+
+        view_nondefault.getCanonical(RDBMS.ORACLE).text == "oracle"
+        view_nondefault.getCanonical(RDBMS.POSTGRES).text == "postgres"
+        view_nondefault.getCanonical(RDBMS.MYSQL).text == null
     }
 }

--- a/src/test/groovy/br/com/bluesoft/bee/service/RulesConverterTest.groovy
+++ b/src/test/groovy/br/com/bluesoft/bee/service/RulesConverterTest.groovy
@@ -1,0 +1,92 @@
+package br.com.bluesoft.bee.service
+
+import br.com.bluesoft.bee.importer.JsonImporter
+import br.com.bluesoft.bee.model.Schema
+import br.com.bluesoft.bee.model.TableColumn
+import br.com.bluesoft.bee.model.rule.DataType
+import br.com.bluesoft.bee.util.RDBMS
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class RulesConverterTest extends Specification {
+
+    @Rule
+    public TemporaryFolder temporaryFolder
+
+    JsonImporter importer
+    Schema metadata
+
+    def setup() {
+
+        [ "tables", "views", "procedures", "packages", "triggers", "usertypes" ].each {
+            File destDir = temporaryFolder.newFolder(it)
+            File srcDir = new File(this.getClass().getResource("/${it}").getFile())
+            srcDir.eachFile {
+                new File(destDir, it.getName()) << it.getText()
+            }
+        }
+
+        [ "sequences.bee", "rules.json" ].each {
+            temporaryFolder.newFile(it) << new File(this.getClass().getResource("/${it}").getFile()).getText()
+        }
+
+        importer = new JsonImporter(temporaryFolder.root.path)
+        metadata = importer.importMetaData()
+        metadata.rdbms = RDBMS.POSTGRES
+    }
+
+    def 'it should convert a table'() {
+        expect:
+        Schema newSchema = new RulesConverter().toSchema(metadata)
+        newSchema.tables[table].columns[column].type == type
+        newSchema.tables[table].columns[column].size == size
+        newSchema.tables[table].columns[column].scale == scale
+        newSchema.tables[table].columns[column].defaultValue == defaultValue
+
+        where:
+        table    |  column                     |  type       |  size  |  scale  |  defaultValue
+        'cof'    |  'codigo_operacao_fiscal'   | 'integer'   |  0     |  0      |  null
+        'cof'    |  'basico'                   | 'number'    |  1     |  0      |  null
+        'pessoa' |  'data_nascimento'          | 'date'      |  7     |  0      |  'current_date'
+        'pessoa' |  'fundacao'                 | 'timestamp' |  7     |  0      |  'current_timestamp'
+
+    }
+
+    def testConvertCheckConstraint() {
+        expect:
+        Schema newSchema = new RulesConverter().toSchema(metadata)
+        newSchema.tables[table].constraints[check].searchCondition == result
+
+        where:
+        table    | check       |  result
+        'cof'    | 'ck_test'   | 'codigo_complementar <> 0'
+        'cof'    | 'ck_test2'  | 'codigo_complementar < 0'
+
+    }
+
+    def testFindDataType() {
+        given:
+        List<DataType> types = [
+                new DataType(fromType: "number", fromSize: 2, fromScale: 0),
+                new DataType(fromType: "number", fromSize: 2, fromScale: 1),
+                new DataType(fromType: "number", fromSize: 2, fromScale: 2),
+                new DataType(fromType: "number", fromSize: 3, fromScale: -1),
+        ]
+        def converter = new RulesConverter()
+
+        expect:
+        (converter.findDataType(column, types) != null) == result
+
+        where:
+        column                                                |  result
+        new TableColumn(type: "number", size: 2, scale: 0) |  true
+        new TableColumn(type: "number", size: 2, scale: 1)    |  true
+        new TableColumn(type: "number", size: 2, scale: null) |  false
+        new TableColumn(type: "number", size: 3, scale: 0)    |  true
+        new TableColumn(type: "number", size: 3, scale: 1)    |  true
+        new TableColumn(type: "number", size: 3, scale: null) |  true
+        new TableColumn(type: "number", size: 4, scale: 1)    |  false
+
+    }
+}

--- a/src/test/groovy/br/com/bluesoft/bee/util/BeeFileUtilsTest.groovy
+++ b/src/test/groovy/br/com/bluesoft/bee/util/BeeFileUtilsTest.groovy
@@ -11,7 +11,6 @@ public class BeeFileUtilsTest extends Specification {
     @Rule
     public TemporaryFolder temporaryFolder
 
-    @Test
     def "deve criar a pasta enviada como parâmetro"() {
         given: ""
         String tempFile = System.getProperty("java.io.tmpdir") + "/bee-tests"
@@ -25,7 +24,6 @@ public class BeeFileUtilsTest extends Specification {
         dir.deleteOnExit()
     }
 
-    @Test
     def "deve remover a pasta enviada como parâmetro"() {
         setup: ""
         def tempFile = temporaryFolder.newFile('test.txt')
@@ -37,7 +35,6 @@ public class BeeFileUtilsTest extends Specification {
         tempFile.exists() == false
     }
 
-    @Test
     def testListBaseJars() {
         given: "Lista de arquivos para testar"
         def files = [
@@ -62,7 +59,6 @@ public class BeeFileUtilsTest extends Specification {
         result == ['bee', 'commons-cli', 'groovy', 'groovy-cli-commons', 'groovy-sql', 'jackson-core-lgpl', 'jackson-mapper-lgpl']
     }
 
-    @Test
     def testRemoveOldJars() {
         given: ""
         Set files = [

--- a/src/test/resources/rules.json
+++ b/src/test/resources/rules.json
@@ -1,0 +1,21 @@
+{
+  "postgres": {
+    "dataTypeOut": [
+      { "fromType": "number", "fromSize": 6, "fromScale":  0, "toType": "integer", "toSize":  0, "toScale":  0 },
+      { "fromType": "boolean", "fromSize": -1, "fromScale":  -1, "toType": "number", "toSize":  1, "toScale":  0 }
+    ],
+    "checkConditionOut": {
+      "codigo_complementar > 0": "codigo_complementar <> 0"
+    },
+    "columnDefaultOut": {
+      "date": {
+        "sysdate": "current_date"
+      },
+      "timestamp": {
+        "sysdate": "current_timestamp"
+      }
+    },
+    "dataTypeIn": [
+    ]
+  }
+}

--- a/src/test/resources/tables/cof.bee
+++ b/src/test/resources/tables/cof.bee
@@ -44,7 +44,7 @@
     },
     basico : {
       name : "basico",
-      type : "number",
+      type : "boolean",
       size : 1,
       nullable : true
     },
@@ -92,6 +92,18 @@
     }
   },
   constraints : {
+    ck_test : {
+      name : "ck_test",
+      searchCondition : "codigo_complementar > 0",
+      status : "enabled",
+      type : "C"
+    },
+    ck_test2 : {
+      name : "ck_test2",
+      searchCondition : "codigo_complementar < 0",
+      status : "enabled",
+      type : "C"
+    },
     pk_cof : {
       name : "pk_cof",
       type : "P",

--- a/src/test/resources/tables/pessoa.bee
+++ b/src/test/resources/tables/pessoa.bee
@@ -46,6 +46,7 @@
       name : "data_nascimento",
       type : "date",
       size : 7,
+      defaultValue: "sysdate",
       nullable : true
     },
     insc : {
@@ -74,8 +75,9 @@
     },
     fundacao : {
       name : "fundacao",
-      type : "date",
+      type : "timestamp",
       size : 7,
+      defaultValue: "sysdate",
       nullable : true
     },
     ean : {


### PR DESCRIPTION
- Added support for multiple database using one schema.
- Changed actions:
  - schema:generate
  - schema:validate
  - schema:recreate_oracle
  - schema:recreate_postgres
  - schema:create_mysql
  - data:generate
  - data:validate
- Added "rules.json" file with table structure changes when creating/validating tables
- Changed view/procedure/trigger/package files to support different databases
- Change dbseed script files to support different databases
